### PR TITLE
Add header access-control-allow-header to '*' in userAPI response.

### DIFF
--- a/backend/userAPI/src/main.ts
+++ b/backend/userAPI/src/main.ts
@@ -20,6 +20,7 @@ async function bootstrap(): Promise<void> {
 	// TODO: Improve security with selected host and headers
 	app.enableCors({
 		credentials: true,
+		allowedHeaders: '*',
 	});
 
 	// Use winston logger


### PR DESCRIPTION
# Description

To fix session issue with flutter, an issue recommend to explicitly send that
header.
Since it doesn't appear in Flutter web, I've explicitly set it in my response.

https://github.com/flutterchina/dio/issues/1027#issue-784047185

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code